### PR TITLE
refine assertArray

### DIFF
--- a/src/Putc.php
+++ b/src/Putc.php
@@ -23,7 +23,7 @@ class Putc extends PHPUnit_Framework_TestCase {
 	}
 
 	protected function assertArray($testing) {
-		return is_array($testing);
+		$this->assertInternalType('array', $testing);
 	}
 
 	protected function assertXml($testing) {


### PR DESCRIPTION
исправляет баг, изза которого не происходит assertion при вызове метода assertArray
