### PR TITLE
refine assertXml

### DIFF
--- a/src/Putc.php
+++ b/src/Putc.php
@@ -27,7 +27,6 @@ class Putc extends PHPUnit_Framework_TestCase {
 	}
 
 	protected function assertXml($testing) {
-		return (bool) simplexml_load_string($testing);
+		return $this->assertNotFalse(simplexml_load_string($testing));
 	}
-
 }


### PR DESCRIPTION
исправляет баг, изза которого не происходит assertion при вызове метода assertXml
